### PR TITLE
encode text before printing

### DIFF
--- a/playing.py
+++ b/playing.py
@@ -56,7 +56,7 @@ def run(data, layout):
         displaystr = parseLayout(layout)
     else:
         sys.stdout.write("   ")
-    print(displaystr)
+    print(displaystr.encode('utf-8'))
 
 parser.add_argument("--layout",
         action="store",

--- a/playing.py
+++ b/playing.py
@@ -56,7 +56,10 @@ def run(data, layout):
         displaystr = parseLayout(layout)
     else:
         sys.stdout.write("   ")
-    print(displaystr.encode('utf-8'))
+    if sys.version[0] == '2':
+        print(displaystr.encode('utf-8'))
+    else:
+        print(displaystr)
 
 parser.add_argument("--layout",
         action="store",


### PR DESCRIPTION
supports foreign characters, fixes:

```
DEBUG sched_start:194: received signal 17 (Child exited)
DEBUG bar_poll_exited:128: [music] exited
DEBUG block_reap:217: [music] process 26980 exited with 1
DEBUG block_reap:227: [music] stderr:
{
Traceback (most recent call last):
  File "/home/byxk/git/GPMDP-PlayerInfo/playing.py", line 71, in <module>
    run(data, "t-a-A-p")
  File "/home/byxk/git/GPMDP-PlayerInfo/playing.py", line 59, in run
    print(displaystr)
UnicodeEncodeError: 'ascii' codec can't encode characters in position 0-2: ordinal not in range(128)

}
ERROR block_reap:239: [music] bad exit code 1
```